### PR TITLE
feat: event 외부 행사 정보 조회 및 내부 DB 통합 기능 구현

### DIFF
--- a/event/build.gradle
+++ b/event/build.gradle
@@ -43,6 +43,13 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+    // QR
+    implementation 'com.google.zxing:core:3.5.3'
+    implementation 'com.google.zxing:javase:3.5.3'
+
+    // Geocoding
+    implementation 'com.google.maps:google-maps-services:2.2.0'
 }
 
 dependencyManagement {

--- a/event/src/main/java/life/eventory/event/EventApplication.java
+++ b/event/src/main/java/life/eventory/event/EventApplication.java
@@ -3,11 +3,13 @@ package life.eventory.event;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableScheduling
 public class EventApplication {
 
     public static void main(String[] args) {

--- a/event/src/main/java/life/eventory/event/controller/EventController.java
+++ b/event/src/main/java/life/eventory/event/controller/EventController.java
@@ -1,5 +1,6 @@
 package life.eventory.event.controller;
 
+import life.eventory.event.controller.api.EventApi;
 import life.eventory.event.dto.ai.AiEventDTO;
 import life.eventory.event.dto.EventDTO;
 import life.eventory.event.dto.LocationDTO;

--- a/event/src/main/java/life/eventory/event/controller/QrController.java
+++ b/event/src/main/java/life/eventory/event/controller/QrController.java
@@ -1,0 +1,10 @@
+package life.eventory.event.controller;
+
+import life.eventory.event.controller.api.QrApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class QrController implements QrApi {
+}

--- a/event/src/main/java/life/eventory/event/controller/api/EventApi.java
+++ b/event/src/main/java/life/eventory/event/controller/api/EventApi.java
@@ -1,4 +1,4 @@
-package life.eventory.event.controller;
+package life.eventory.event.controller.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/event/src/main/java/life/eventory/event/controller/api/QrApi.java
+++ b/event/src/main/java/life/eventory/event/controller/api/QrApi.java
@@ -1,0 +1,9 @@
+package life.eventory.event.controller.api;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "QR API", description = "QR API")
+@RequestMapping("/api/event/qr")
+public interface QrApi {
+}

--- a/event/src/main/java/life/eventory/event/dto/external/ConvertAddress.java
+++ b/event/src/main/java/life/eventory/event/dto/external/ConvertAddress.java
@@ -1,0 +1,15 @@
+package life.eventory.event.dto.external;
+
+import lombok.*;
+
+@ToString
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConvertAddress {
+    private String address;
+    private Double latitude;
+    private Double longitude;
+}

--- a/event/src/main/java/life/eventory/event/dto/external/DaeguEventDTO.java
+++ b/event/src/main/java/life/eventory/event/dto/external/DaeguEventDTO.java
@@ -1,0 +1,27 @@
+package life.eventory.event.dto.external;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class DaeguEventDTO {
+    private Long event_seq;
+    private String event_gubun;
+    private String subject;
+    private LocalDate start_date;
+    private LocalDate end_date;
+    private String place;
+    private String event_area;
+    private String host;
+    private String contact;
+    private String pay_gubun;
+    private String pay;
+    private String homepage;
+    private String content;
+}

--- a/event/src/main/java/life/eventory/event/entity/Event.java
+++ b/event/src/main/java/life/eventory/event/entity/Event.java
@@ -26,7 +26,8 @@ public class Event {
     private String name;
     // Poster는 null 허용
     private Long posterId;
-    @Column(nullable = false)
+    @Lob
+    @Column(nullable = false, columnDefinition = "MEDIUMTEXT")
     private String description;
     @Column(nullable = false)
     private LocalDateTime startTime;

--- a/event/src/main/java/life/eventory/event/repository/EventRepository.java
+++ b/event/src/main/java/life/eventory/event/repository/EventRepository.java
@@ -89,4 +89,11 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("select distinct e from Event e join e.tags t where t.name in :names")
     Page<Event> findByTagNames(@Param("names") Collection<String> names, Pageable pageable);
+
+    @Query("""
+    select case when count(e) > 0 then true else false end
+    from Event e
+    where e.organizerId = 0 and e.name = :name
+    """)
+    boolean existsExternalEvent(String name);
 }

--- a/event/src/main/java/life/eventory/event/service/ExternalEventInfoAggregator.java
+++ b/event/src/main/java/life/eventory/event/service/ExternalEventInfoAggregator.java
@@ -1,0 +1,156 @@
+package life.eventory.event.service;
+
+import com.google.maps.GeoApiContext;
+import com.google.maps.GeocodingApi;
+import com.google.maps.errors.ApiException;
+import com.google.maps.model.GeocodingResult;
+import com.google.maps.model.LatLng;
+import jakarta.annotation.PostConstruct;
+import life.eventory.event.dto.external.ConvertAddress;
+import life.eventory.event.dto.external.DaeguEventDTO;
+import life.eventory.event.entity.Event;
+import life.eventory.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExternalEventInfoAggregator {
+    private final RestTemplate restTemplate;
+    private final EventRepository eventRepository;
+    private final EventTagService eventTagService;
+
+    @Value("${geocoding.api}")
+    private String geocodingApi;
+
+    private List<DaeguEventDTO> getDaeguEvent() {
+        // 로컬 테스트 코드 예시
+        URI uri = UriComponentsBuilder.fromUri(URI.create("https://dgfca.or.kr"))
+                .path("/api/daegu/cultural-events")
+                .build()
+                .toUri();
+
+        // 요청 헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // 요청 HTTP 엔티티 생성
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(null, headers);
+
+        try {
+            ResponseEntity<List<DaeguEventDTO>> response =
+                    restTemplate.exchange(uri,
+                            HttpMethod.GET,
+                            requestEntity,
+                            new ParameterizedTypeReference<>() {}
+                    );
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return response.getBody();
+            }
+
+            throw new IllegalStateException("Failed to get daegu event");
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to send request to 대구문화예술진흥원", e);
+        }
+    }
+
+    // 외부 행사 정보 변환 및 DB 저장 / 매일 0시 업데이트
+    @PostConstruct
+    @Scheduled(cron = "0 0 0 1 * *")
+    private void transformAndSaveEvents() throws IOException, InterruptedException, ApiException {
+        final LocalDate cutOff = LocalDate.of(2025, 1, 1);
+
+        for (DaeguEventDTO daeguEventDTO : getDaeguEvent()) {
+            // 2025년 이후로 필터, 이미 존재하는 정보인지 확인
+            if (daeguEventDTO.getStart_date().isAfter(cutOff))
+                continue;
+
+            if (eventRepository.existsExternalEvent(daeguEventDTO.getSubject()))
+                continue;
+
+            //주소 변환
+            ConvertAddress convertAddress = convertToDetail(daeguEventDTO.getPlace(), daeguEventDTO.getEvent_area());
+
+            if (convertAddress != null) {
+                Event externalEvent = Event.builder()
+                        .organizerId(0L) // 외부 행사는 0 으로 고정
+                        .name(daeguEventDTO.getSubject())
+                        .posterId(null)
+                        .description(daeguEventDTO.getContent())
+                        .startTime(toStartOfDay(daeguEventDTO.getStart_date()))
+                        .endTime(toStartOfDay(daeguEventDTO.getEnd_date()))
+                        .address(convertAddress.getAddress())
+                        .latitude(convertAddress.getLatitude())
+                        .longitude(convertAddress.getLongitude())
+                        .createTime(LocalDateTime.now())
+                        .entryFee(parseEntryFee(daeguEventDTO.getPay()))
+                        .build();
+
+                eventTagService.setEventHashtags(
+                        eventRepository.save(externalEvent).getId(),
+                        List.of(daeguEventDTO.getEvent_gubun())
+                );
+            }
+        }
+    }
+
+    // 자정기준 변환 LocalDate -> LocalDateTime
+    private static LocalDateTime toStartOfDay(LocalDate date) {
+        return date.atStartOfDay();
+    }
+
+    // 주소, 좌표 변환
+    private ConvertAddress convertToDetail(String place, String event_area) throws IOException, InterruptedException, ApiException {
+        GeoApiContext context = new GeoApiContext.Builder()
+                .apiKey(geocodingApi)
+                .build();
+
+        GeocodingResult[] results = GeocodingApi.geocode(context, place + " " + event_area)
+                .language("ko") // 한글 주소
+                .await();
+
+        if (results.length == 0) {
+            return null;
+        }
+
+        LatLng location = results[0].geometry.location;
+        String address = results[0].formattedAddress;
+
+        return ConvertAddress.builder()
+                .address(address)
+                .latitude(location.lat)
+                .longitude(location.lng)
+                .build();
+    }
+
+    // 입장료 변환
+    private Integer parseEntryFee(String pay) {
+        if (pay == null || pay.isBlank()) return 0;
+
+        var matcher = java.util.regex.Pattern.compile("(\\d+)")
+                .matcher(pay.replaceAll(",", ""));
+
+        List<Integer> prices = new ArrayList<>();
+        while (matcher.find()) {
+            prices.add(Integer.parseInt(matcher.group(1)));
+        }
+
+        return prices.isEmpty() ? 0 : Collections.max(prices);
+    }
+}

--- a/event/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/event/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "geocoding.api",
+      "type": "java.lang.String",
+      "description": "Geocoding api key."
+  }
+] }

--- a/event/src/main/resources/application.properties
+++ b/event/src/main/resources/application.properties
@@ -23,3 +23,5 @@ spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB
 
 spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
+
+geocoding.api=${GEOCODING_API_KEY}


### PR DESCRIPTION
<!-- 
PR 제목 작성:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- refactor: 코드 리팩토링
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 로그인 및 회원가입 페이지 구현 (#1)
-->


### ✅ 작업 내용
- 대구 지역 행사 조회 API 이용하여 행사 조회
- 2025년 기준 필터
- DB 존재 여부 판별 필터
- 구글 Geocoding API 이용하여 주소, 좌표 변환
- 내부 DB 스키마에 맞게 변환 및 저장
- 서버 최초 실행 시 구동, 달에 1번 최신화

### 🐞 관련 이슈
- Related to: #21


### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [x] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인